### PR TITLE
Add FTC disclosure in articles and footer

### DIFF
--- a/catdata-pipeline/cms_publish/cms_publish.py
+++ b/catdata-pipeline/cms_publish/cms_publish.py
@@ -13,9 +13,15 @@ CONTENT_DIR = Path(__file__).resolve().parents[1] / "content"
 CMS_API_URL = os.getenv("CMS_API_URL", "https://cms.example.com/api/pages")
 CMS_API_KEY = os.getenv("CMS_API_KEY", "")
 
+# FTC affiliate disclosure used across all published pages
+FTC_DISCLOSURE = "As an Amazon Associate I earn from qualifying purchases."
+
 
 def publish_page(title: str, body: str) -> None:
     """Create or update a page via Lovable CMS API."""
+    # Ensure disclosure is present before publishing
+    if FTC_DISCLOSURE not in body:
+        body = f"{FTC_DISCLOSURE}\n\n{body}"
     payload = {
         "title": title,
         "body": body,

--- a/catdata-pipeline/content_gen/content_gen.py
+++ b/catdata-pipeline/content_gen/content_gen.py
@@ -20,6 +20,9 @@ ARTICLE_PROMPT_TEMPLATE = (
 
 openai.api_key = os.getenv("OPENAI_API_KEY", "")
 
+# FTC affiliate disclosure used across all generated content
+FTC_DISCLOSURE = "As an Amazon Associate I earn from qualifying purchases."
+
 
 def generate_article(topic: str, rating_data: Dict) -> str:
     """Generate article content via OpenAI ChatCompletion."""
@@ -29,7 +32,9 @@ def generate_article(topic: str, rating_data: Dict) -> str:
             model="gpt-3.5-turbo",
             messages=[{"role": "user", "content": prompt}],
         )
-        return resp.choices[0].message["content"].strip()
+        article = resp.choices[0].message["content"].strip()
+        # Add FTC disclosure to the beginning and end of the article
+        return f"{FTC_DISCLOSURE}\n\n{article}\n\n{FTC_DISCLOSURE}"
     except Exception as e:
         return f"Error generating article for {topic}: {e}"
 

--- a/src/components/sections/Footer.tsx
+++ b/src/components/sections/Footer.tsx
@@ -37,6 +37,8 @@ const Footer = () => {
         </div>
         <div className="border-t border-navy-700 mt-8 pt-8 text-center text-navy-400">
           <p>&copy; 2024 CatData AI. Made with 💙 by cat parents, for cat parents.</p>
+          {/* FTC affiliate disclosure in site-wide footer */}
+          <p className="mt-2 text-sm">As an Amazon Associate I earn from qualifying purchases.</p>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
## Summary
- automatically insert FTC affiliate disclosure into generated articles
- ensure CMS payload contains the disclosure
- add disclosure to site-wide footer

## Testing
- `bun run lint` *(fails: 3 errors, 7 warnings)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686306ab9eb4832f8c7afd6cb1fcfe5c