### PR TITLE
Enable manual workflow trigger

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -3,6 +3,7 @@ name: CatData Pipeline Schedule
 on:
   schedule:
     - cron: '0 8 * * 1'
+  workflow_dispatch:
 
 jobs:
   run-pipeline:

--- a/enable_manual_run.sh
+++ b/enable_manual_run.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Script to enable manual trigger for CatData Pipeline workflow
+
+set -e
+
+if [ ! -f .github/workflows/schedule.yml ]; then
+  echo "Error: .github/workflows/schedule.yml not found" >&2
+  exit 1
+fi
+
+# Add workflow_dispatch after the cron schedule if not present
+if ! grep -q '^  workflow_dispatch:' .github/workflows/schedule.yml; then
+  sed -i "/cron: '0 8 * * 1'/a\  workflow_dispatch:" .github/workflows/schedule.yml
+fi
+
+# Commit and push
+git add .github/workflows/schedule.yml
+git commit -m "Enable manual trigger for CatData Pipeline workflow"
+
+git push origin main


### PR DESCRIPTION
## Summary
- add manual dispatch trigger for CatData pipeline schedule
- provide enable_manual_run.sh helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError openai/requests; later 3 tests fail)*
- `git push origin HEAD` *(fails: 'origin' does not appear to be a git repository)*

------
https://chatgpt.com/codex/tasks/task_e_68630be4e114832f88545313edb82edc