### PR TITLE
Add workflow_dispatch to pipeline

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -1,6 +1,7 @@
 name: CatData Pipeline Schedule
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 8 * * 1'
 


### PR DESCRIPTION
## Summary
- enable manual runs for CatData pipeline

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68632aec093c832fbb23cc0d7b2be76e