### PR TITLE
Update data ingestion to use sheet

### DIFF
--- a/catdata-pipeline/cms_publish/cms_publish.py
+++ b/catdata-pipeline/cms_publish/cms_publish.py
@@ -14,11 +14,19 @@ CONTENT_DIR = Path(__file__).resolve().parents[1] / "content"
 CMS_API_URL = os.getenv("CMS_API_URL", "https://cms.example.com/api/pages")
 CMS_API_KEY = os.getenv("CMS_API_KEY", "")
 
+# Disclosure line inserted into every published page if missing
+DISCLOSURE_LINE = (
+    "FTC Disclosure: This post contains affiliate links. "
+    "If you make a purchase, we may earn a commission."
+)
+
 logging.basicConfig(level=logging.ERROR, format="%(asctime)s %(levelname)s %(message)s")
 
 
 def publish_page(title: str, body: str) -> bool:
     """Create or update a page via Lovable CMS API."""
+    if not body.startswith(DISCLOSURE_LINE):
+        body = f"{DISCLOSURE_LINE}\n\n{body}"
     payload = {
         "title": title,
         "body": body,

--- a/catdata-pipeline/content_gen/content_gen.py
+++ b/catdata-pipeline/content_gen/content_gen.py
@@ -25,6 +25,12 @@ ARTICLE_PROMPT_TEMPLATE = (
 
 openai.api_key = os.getenv("OPENAI_API_KEY", "")
 
+# FTC disclosure automatically inserted at the beginning of every article
+DISCLOSURE_LINE = (
+    "FTC Disclosure: This post contains affiliate links. "
+    "If you make a purchase, we may earn a commission."
+)
+
 
 def generate_article(topic: str, rating_data: Dict) -> str:
     """Generate article content via OpenAI ChatCompletion."""
@@ -36,6 +42,8 @@ def generate_article(topic: str, rating_data: Dict) -> str:
             model="gpt-3.5-turbo",
             messages=[{"role": "user", "content": prompt}],
         )
+        body = resp.choices[0].message["content"].strip()
+        return f"{DISCLOSURE_LINE}\n\n{body}"
     except Exception as e:
         logging.error("Error generating article for %s: %s", topic, e)
         return f"Error generating article for {topic}: {e}"


### PR DESCRIPTION
## Summary
- fetch CSV from env `SHEET_CSV_URL` with local fallback
- parse rows to ratings format for `ratings_raw.json`
- keep articles and CMS publishing prefixed with disclosure line

## Testing
- `pip install -q -r catdata-pipeline/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68632af3d5d4832faedafbcd5a017420