### PR TITLE
Update pipeline docs and add disclosure handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,107 +1,50 @@
-# Welcome to your Lovable project
+# Purrfect Product Finder
 
-## Project info
+## Repository overview
 
-**URL**: https://lovable.dev/projects/e269439c-4498-4223-b902-045ee9c9aa66
+This project powers the **Purrfect Product Finder** website. The frontend is built with Vite, React and TypeScript while the `catdata-pipeline` directory contains a Python workflow that automatically gathers rating data, generates articles and publishes them to a CMS.  The pipeline runs weekly through GitHub Actions but can also be triggered manually.
 
-## How can I edit this code?
+## Environment variables
 
-There are several ways of editing your application.
+The pipeline expects several environment variables to be set when running locally or in CI:
 
-**Use Lovable**
-
-Simply visit the [Lovable Project](https://lovable.dev/projects/e269439c-4498-4223-b902-045ee9c9aa66) and start prompting.
-
-Changes made via Lovable will be committed automatically to this repo.
-
-**Use your preferred IDE**
-
-If you want to work locally using your own IDE, you can clone this repo and push changes. Pushed changes will also be reflected in Lovable.
-
-The only requirement is having Node.js & npm installed - [install with nvm](https://github.com/nvm-sh/nvm#installing-and-updating)
-
-Follow these steps:
-
-```sh
-# Step 1: Clone the repository using the project's Git URL.
-git clone <YOUR_GIT_URL>
-
-# Step 2: Navigate to the project directory.
-cd <YOUR_PROJECT_NAME>
-
-# Step 3: Install the necessary dependencies.
-npm i
-
-# Step 4: Start the development server with auto-reloading and an instant preview.
-npm run dev
-```
-
-**Edit a file directly in GitHub**
-
-- Navigate to the desired file(s).
-- Click the "Edit" button (pencil icon) at the top right of the file view.
-- Make your changes and commit the changes.
-
-**Use GitHub Codespaces**
-
-- Navigate to the main page of your repository.
-- Click on the "Code" button (green button) near the top right.
-- Select the "Codespaces" tab.
-- Click on "New codespace" to launch a new Codespace environment.
-- Edit files directly within the Codespace and commit and push your changes once you're done.
-
-## What technologies are used for this project?
-
-This project is built with:
-
-- Vite
-- TypeScript
-- React
-- shadcn-ui
-- Tailwind CSS
-
-## How can I deploy this project?
-
-Simply open [Lovable](https://lovable.dev/projects/e269439c-4498-4223-b902-045ee9c9aa66) and click on Share -> Publish.
-
-## Can I connect a custom domain to my Lovable project?
-
-Yes, you can!
-
-To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
-
-Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
-
-## CatData AI Pipeline
-
-This repository includes an automated pipeline in the `catdata-pipeline` directory.
-The workflow downloads rating data, computes scores, generates articles with the
-FTC disclosure, updates affiliate links, publishes the content and records
-analytics. The pipeline is executed weekly by a GitHub Actions schedule.
-
-### Pipeline steps
-
-1. **Data ingestion** – `data_ingest/data_ingest.py` fetches topic ratings from
-   `RATINGS_API_TEMPLATE` and stores them in `data/ratings_raw.json`.
-2. **Rating computation** – `rating/rating.py` adds a `lives_rating` to each entry.
-3. **Content generation** – `content_gen/content_gen.py` creates markdown files
-   prefixed with the required FTC disclosure.
-4. **Affiliate update** – `utils/affiliates.py` replaces placeholders with real
-   URLs from `affiliates.csv`.
-5. **Publishing** – `cms_publish/cms_publish.py` pushes pages to your CMS.
-6. **Analytics** – `analytics_monitor/analytics_monitor.py` stores basic metrics.
-
-### Environment variables
-
-- `OPENAI_API_KEY` – API key for content generation.
+- `SHEET_CSV_URL` – URL of the product sheet in CSV form. Used to sync `affiliates.csv`.
+- `OPENAI_API_KEY` – API key used by `content_gen/content_gen.py`.
 - `CMS_API_URL` – Endpoint for publishing pages.
 - `CMS_API_KEY` – Authentication token for the CMS.
-- `RATINGS_API_TEMPLATE` – Template URL for rating ingestion.
-- `ANALYTICS_API_URL` / `ANALYTICS_API_KEY` – Analytics endpoints.
-- `SLACK_WEBHOOK_URL` – Webhook used by the scheduled workflow for failure alerts.
+- `RATINGS_API_TEMPLATE` – Template URL for rating ingestion (`https://example.com/api/{topic}` by default).
+- `ANALYTICS_API_URL` / `ANALYTICS_API_KEY` – Analytics endpoints and key.
+- `SLACK_WEBHOOK_URL` – Webhook used for failure notifications in the scheduled workflow.
 
-### Adding affiliate links
+## Triggering the pipeline manually
 
-Affiliate placeholders like `{{amazon:Cat Food A}}` are replaced according to
-`catdata-pipeline/affiliates.csv`. Add new rows to that CSV and run the
-pipeline (or `python catdata-pipeline/utils/affiliates.py`) to update links.
+The weekly workflow lives in `.github/workflows/schedule.yml`. To run all stages on demand:
+
+```sh
+# Ensure GitHub CLI is installed and authenticated
+./merge_and_run.sh
+```
+
+This script merges the `pipeline` branch into `main`, pushes the changes, and triggers the **CatData Pipeline Schedule** workflow via GitHub Actions.
+
+If you just want to run the steps locally without GitHub Actions you can execute each module in order:
+
+```sh
+python catdata-pipeline/data_ingest/data_ingest.py
+python catdata-pipeline/rating/rating.py
+python catdata-pipeline/content_gen/content_gen.py
+python catdata-pipeline/utils/affiliates.py
+python catdata-pipeline/cms_publish/cms_publish.py
+python catdata-pipeline/analytics_monitor/analytics_monitor.py
+```
+
+## Adding or updating products
+
+Product affiliate links are stored in `catdata-pipeline/affiliates.csv`. To add a product or change URLs:
+
+1. Edit the CSV locally or update the remote sheet pointed to by `SHEET_CSV_URL`.
+2. Run the pipeline (either via `./merge_and_run.sh` or the individual commands above). The `utils/affiliates.py` step will update markdown files with the new links.
+
+---
+
+See `docs/pipeline.md` for a high level diagram of the workflow.

--- a/catdata-pipeline/cms_publish/cms_publish.py
+++ b/catdata-pipeline/cms_publish/cms_publish.py
@@ -14,11 +14,18 @@ CONTENT_DIR = Path(__file__).resolve().parents[1] / "content"
 CMS_API_URL = os.getenv("CMS_API_URL", "https://cms.example.com/api/pages")
 CMS_API_KEY = os.getenv("CMS_API_KEY", "")
 
+DISCLOSURE_LINE = (
+    "FTC disclosure: This article contains affiliate links and we may earn"
+    " a commission on qualifying purchases."
+)
+
 logging.basicConfig(level=logging.ERROR, format="%(asctime)s %(levelname)s %(message)s")
 
 
 def publish_page(title: str, body: str) -> bool:
     """Create or update a page via Lovable CMS API."""
+    if not body.startswith(DISCLOSURE_LINE):
+        body = f"{DISCLOSURE_LINE}\n\n{body}"
     payload = {
         "title": title,
         "body": body,

--- a/catdata-pipeline/content_gen/content_gen.py
+++ b/catdata-pipeline/content_gen/content_gen.py
@@ -15,6 +15,11 @@ CONTENT_DIR = Path(__file__).resolve().parents[1] / "content"
 CONTENT_DIR.mkdir(exist_ok=True)
 RATINGS_FILE = DATA_DIR / "ratings.json"
 
+DISCLOSURE_LINE = (
+    "FTC disclosure: This article contains affiliate links and we may earn"
+    " a commission on qualifying purchases."
+)
+
 logging.basicConfig(
     level=logging.ERROR, format="%(asctime)s %(levelname)s %(message)s"
 )
@@ -36,6 +41,8 @@ def generate_article(topic: str, rating_data: Dict) -> str:
             model="gpt-3.5-turbo",
             messages=[{"role": "user", "content": prompt}],
         )
+        content = resp.choices[0].message["content"]
+        return f"{DISCLOSURE_LINE}\n\n{content}"
     except Exception as e:
         logging.error("Error generating article for %s: %s", topic, e)
         return f"Error generating article for {topic}: {e}"


### PR DESCRIPTION
## Summary
- add overview and setup instructions in `README.md`
- enforce FTC disclosure in content generation and CMS publish scripts
- document pipeline environment variables and manual run steps

## Testing
- `flake8 catdata-pipeline`
- `pytest catdata-pipeline`


------
https://chatgpt.com/codex/tasks/task_e_68632b313d1c832faf4134895a3855d0