### PR TITLE
Add analytics dashboard notebook

### DIFF
--- a/analytics_dashboard.ipynb
+++ b/analytics_dashboard.ipynb
@@ -1,0 +1,74 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8be2cab7",
+   "metadata": {},
+   "source": [
+    "# Analytics Dashboard\n",
+    "\n",
+    "This notebook helps visualize performance data. It expects a file `reports/summary.csv` containing columns like `date`, `clicks`, and `revenue`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13a1b2de",
+   "metadata": {},
+   "source": [
+    "## 1. Load the data\n",
+    "Run the cell below to read the CSV file. Make sure the `reports` folder is in the same directory as this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2dd09606",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "summary = pd.read_csv('reports/summary.csv')\n",
+    "summary.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca557b69",
+   "metadata": {},
+   "source": [
+    "## 2. Plot clicks and revenue\n",
+    "The next cell creates a simple line chart to show how clicks and revenue change over time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33ec86dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "plt.plot(summary['date'], summary['clicks'], label='Clicks')\n",
+    "plt.plot(summary['date'], summary['revenue'], label='Revenue')\n",
+    "plt.xlabel('Date')\n",
+    "plt.legend()\n",
+    "plt.xticks(rotation=45)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a23542d",
+   "metadata": {},
+   "source": [
+    "You're done! The chart above should help you see trends in your site's performance."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add `analytics_dashboard.ipynb` to visualize clicks and revenue from `reports/summary.csv`

## Testing
- `pre-commit run --files analytics_dashboard.ipynb`
- `pytest -q` *(fails: AttributeError: module 'cms_publish' has no attribute 'DISCLOSURE_LINE')*

------
https://chatgpt.com/codex/tasks/task_e_68632b3aa904832f8f1fa3f1be69718c