### PR TITLE
Update data ingestion to support sheet CSV

### DIFF
--- a/catdata-pipeline/data_ingest/data_ingest.py
+++ b/catdata-pipeline/data_ingest/data_ingest.py
@@ -1,14 +1,15 @@
 """Data ingestion module for CatData AI project.
 
-Fetches weekly JSON rating arrays for six topics and saves them to
-`data/ratings_raw.json`.
+Fetches affiliate product information from a Google Sheet CSV or a local
+fallback and stores it in ``data/ratings_raw.json``.
 """
 
 from __future__ import annotations
 
 import json
 import os
-import random
+import csv
+import io
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -20,57 +21,52 @@ import requests
 DATA_DIR = Path(__file__).resolve().parents[1] / "data"
 DATA_DIR.mkdir(exist_ok=True)
 RAW_RATINGS_FILE = DATA_DIR / "ratings_raw.json"
+AFFILIATE_CSV = Path(__file__).resolve().parents[1] / "affiliates.csv"
 
 logging.basicConfig(level=logging.ERROR, format="%(asctime)s %(levelname)s %(message)s")
 
-TOPICS = [
-    "food",
-    "toys",
-    "health",
-    "training",
-    "grooming",
-    "behavior",
-]
 
-API_TEMPLATE = os.getenv("RATINGS_API_TEMPLATE", "https://example.com/api/{topic}")
+def load_csv_rows() -> List[Dict[str, str]]:
+    """Load affiliate rows from Google Sheets or local CSV."""
+    sheet_url = os.getenv("SHEET_CSV_URL")
+    if sheet_url:
+        try:
+            resp = requests.get(sheet_url, timeout=10)
+            resp.raise_for_status()
+            return list(csv.DictReader(io.StringIO(resp.text)))
+        except Exception as e:
+            logging.error("Failed to download sheet CSV: %s", e)
 
-
-def fetch_topic_ratings(topic: str) -> List[Dict[str, float]]:
-    """Fetch ratings for a single topic from remote API.
-
-    The returned object is expected to be a list of dictionaries with keys
-    ``durability``, ``safety``, ``value`` and ``convenience``. In case the
-    request fails, random data is returned as a fallback so the pipeline can
-    continue to run without external dependencies during testing.
-    """
-    url = API_TEMPLATE.format(topic=topic)
     try:
-        response = requests.get(url, timeout=10)
-        response.raise_for_status()
-        return response.json()
+        with AFFILIATE_CSV.open() as f:
+            return list(csv.DictReader(f))
     except Exception as e:
-        logging.error("Failed to fetch %s ratings: %s", topic, e)
-        # Fallback: generate dummy rating data
-        return [
-            {
-                "durability": random.uniform(0, 5),
-                "safety": random.uniform(0, 5),
-                "value": random.uniform(0, 5),
-                "convenience": random.uniform(0, 5),
-            }
-            for _ in range(5)
-        ]
+        logging.error("Failed to read local CSV: %s", e)
+        return []
 
 
 def main() -> None:
-    """Fetch all topic ratings and save to RAW_RATINGS_FILE."""
-    all_ratings = {}
-    for topic in TOPICS:
-        all_ratings[topic] = fetch_topic_ratings(topic)
+    """Load affiliate data and save to ``RAW_RATINGS_FILE``."""
+    rows = load_csv_rows()
+    all_ratings: List[Dict[str, str]] = []
+    for row in rows:
+        all_ratings.append(
+            {
+                "product_name": row.get("product_name", ""),
+                "amazon_url": row.get("amazon_url", ""),
+                "chewy_url": row.get("chewy_url", ""),
+                "direct_url": row.get("direct_url", ""),
+                "image_url": row.get("image_url", ""),
+            }
+        )
+
     try:
         RAW_RATINGS_FILE.write_text(
             json.dumps(
-                {"generated": datetime.utcnow().isoformat(), "ratings": all_ratings},
+                {
+                    "generated": datetime.utcnow().isoformat(),
+                    "ratings": all_ratings,
+                },
                 indent=2,
             )
         )


### PR DESCRIPTION
## Summary
- fetch affiliate data from SHEET_CSV_URL when available
- fall back to reading `affiliates.csv`
- output list of product dictionaries to `ratings_raw.json`

## Testing
- `flake8 catdata-pipeline`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68632dab1ff0832f996da4921d7f859e