### PR TITLE
Ensure disclosures wrap generated articles

### DIFF
--- a/catdata-pipeline/content_gen/content_gen.py
+++ b/catdata-pipeline/content_gen/content_gen.py
@@ -12,6 +12,12 @@ import openai
 
 DISCLOSURE_LINE = "As an Amazon Associate I earn from qualifying purchases."
 
+
+def add_disclosure(text: str) -> str:
+    """Wrap text with the disclosure line at the top and bottom."""
+    lines = [DISCLOSURE_LINE, "", text.strip(), "", DISCLOSURE_LINE]
+    return "\n".join(lines)
+
 DATA_DIR = Path(__file__).resolve().parents[1] / "data"
 CONTENT_DIR = Path(__file__).resolve().parents[1] / "content"
 CONTENT_DIR.mkdir(exist_ok=True)
@@ -43,7 +49,7 @@ def generate_article(topic: str, rating_data: Dict) -> str:
         return f"Error generating article for {topic}: {e}"
 
     content = resp.choices[0].message["content"]
-    return f"{DISCLOSURE_LINE}\n\n{content}\n\n{DISCLOSURE_LINE}"
+    return add_disclosure(content)
 
 
 def main() -> None:

--- a/catdata-pipeline/content_gen/tests/test_disclosure.py
+++ b/catdata-pipeline/content_gen/tests/test_disclosure.py
@@ -17,3 +17,4 @@ def test_generate_article_includes_disclosure(mock_create):
     mock_create.return_value = FakeResponse("Generated text")
     result = content_gen.generate_article("cats", {})
     assert result.startswith(content_gen.DISCLOSURE_LINE)
+    assert result.rstrip().endswith(content_gen.DISCLOSURE_LINE)


### PR DESCRIPTION
## Summary
- add helper to wrap article text with disclosure line
- ensure disclosure is added at bottom of generated article
- test for presence of disclosure line at both beginning and end of article

## Testing
- `pytest -q catdata-pipeline/content_gen/tests/test_disclosure.py`


------
https://chatgpt.com/codex/tasks/task_e_68632ddfb510832fa7f8519710350b36