### PR TITLE
Enhance rating edge cases

### DIFF
--- a/catdata-pipeline/rating/rating.py
+++ b/catdata-pipeline/rating/rating.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import List, Dict
+import logging
 import math
 
 DATA_DIR = Path(__file__).resolve().parents[1] / "data"
@@ -18,6 +19,8 @@ WEIGHTS = {
     "convenience": 0.2,
 }
 
+logger = logging.getLogger(__name__)
+
 
 def compute_lives_rating(entry: Dict[str, float]) -> float:
     """Compute weighted lives rating on a scale of 1-9.
@@ -27,7 +30,9 @@ def compute_lives_rating(entry: Dict[str, float]) -> float:
     """
     score = 0.0
     for key, weight in WEIGHTS.items():
-        value = entry.get(key, 0)
+        if key not in entry:
+            logger.warning("Missing key '%s' when computing rating", key)
+        value = entry.get(key, 0.0)
         try:
             value = float(value)
         except (TypeError, ValueError):
@@ -36,10 +41,10 @@ def compute_lives_rating(entry: Dict[str, float]) -> float:
             value = 0.0
         score += value * weight
 
-    rating = score / 5 * 8 + 1
+    rating = float(score) / 5 * 8 + 1
     if math.isnan(rating) or math.isinf(rating):
         rating = 1.0
-    return max(1.0, min(9.0, rating))
+    return float(max(1.0, min(9.0, rating)))
 
 
 def process_ratings(raw_data: Dict[str, List[Dict[str, float]]]) -> Dict[str, List[Dict[str, float]]]:

--- a/catdata-pipeline/rating/tests/test_rating_edge_cases.py
+++ b/catdata-pipeline/rating/tests/test_rating_edge_cases.py
@@ -1,0 +1,61 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "rating"))
+
+import math
+import pytest
+from rating import compute_lives_rating, process_ratings
+
+
+@pytest.fixture
+
+def zero_entry():
+    return {"durability": 0, "safety": 0, "value": 0, "convenience": 0}
+
+
+@pytest.fixture
+def missing_key_entry():
+    return {"durability": 2, "safety": 3}
+
+
+@pytest.fixture
+def non_numeric_entry():
+    return {"durability": "high", "safety": None, "value": "4", "convenience": []}
+
+
+@pytest.fixture
+def multi_product_data():
+    return {
+        "toys": [
+            {"durability": 1, "safety": 2, "value": 3, "convenience": 4},
+            {"durability": 4, "safety": 3, "value": 2, "convenience": 1},
+        ]
+    }
+
+
+def test_all_zero_scores(zero_entry):
+    rating = compute_lives_rating(zero_entry)
+    assert rating == 1.0
+
+
+def test_missing_keys_logged_and_defaults(missing_key_entry, caplog):
+    with caplog.at_level("WARNING"):
+        rating = compute_lives_rating(missing_key_entry)
+    assert any("Missing key" in rec.message for rec in caplog.records)
+    assert 1.0 <= rating <= 9.0 and not math.isnan(rating)
+
+
+def test_non_numeric_values(non_numeric_entry):
+    rating = compute_lives_rating(non_numeric_entry)
+    assert 1.0 <= rating <= 9.0 and not math.isnan(rating)
+
+
+def test_process_ratings_preserves_count(multi_product_data):
+    processed = process_ratings(multi_product_data)
+    assert len(processed["toys"]) == len(multi_product_data["toys"])
+    for entry in processed["toys"]:
+        assert "lives_rating" in entry
+        r = entry["lives_rating"]
+        assert isinstance(r, float)
+        assert 1.0 <= r <= 9.0


### PR DESCRIPTION
## Summary
- handle missing and invalid sub-scores in `compute_lives_rating`
- log warnings for missing keys
- ensure output is always a float between 1 and 9
- cover edge cases for rating calculations

## Testing
- `pytest -q catdata-pipeline/rating/tests/test_rating.py catdata-pipeline/rating/tests/test_rating_edge_cases.py`

------
https://chatgpt.com/codex/tasks/task_e_68632ddb4224832fb243d7e97e867f19