### PR TITLE
Enhance pipeline error handling

### DIFF
--- a/catdata-pipeline/analytics_monitor/analytics_monitor.py
+++ b/catdata-pipeline/analytics_monitor/analytics_monitor.py
@@ -8,15 +8,23 @@ from pathlib import Path
 from typing import List
 
 import requests
+import logging
+import sys
 
 REPORTS_DIR = Path(__file__).resolve().parents[1] / "reports"
-REPORTS_DIR.mkdir(exist_ok=True)
+try:
+    REPORTS_DIR.mkdir(exist_ok=True)
+except Exception as e:
+    logging.error("Failed to create reports directory: %s", e)
+    sys.exit(1)
 SUMMARY_FILE = REPORTS_DIR / "summary.csv"
 
 ANALYTICS_API_URL = os.getenv(
     "ANALYTICS_API_URL", "https://analytics.example.com/api/summary"
 )
 API_KEY = os.getenv("ANALYTICS_API_KEY", "")
+
+logging.basicConfig(level=logging.ERROR, format="%(asctime)s %(levelname)s %(message)s")
 
 
 def fetch_summary() -> List[dict]:
@@ -29,15 +37,20 @@ def fetch_summary() -> List[dict]:
         return []
 
 
-def write_summary(rows: List[dict]) -> None:
+def write_summary(rows: List[dict]) -> bool:
     fieldnames = ["date", "clicks", "revenue"]
     exists = SUMMARY_FILE.exists()
-    with SUMMARY_FILE.open("a", newline="") as f:
-        writer = csv.DictWriter(f, fieldnames=fieldnames)
-        if not exists:
-            writer.writeheader()
-        for row in rows:
-            writer.writerow(row)
+    try:
+        with SUMMARY_FILE.open("a", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            if not exists:
+                writer.writeheader()
+            for row in rows:
+                writer.writerow(row)
+        return True
+    except Exception as e:
+        logging.error("Failed to write summary file: %s", e)
+        return False
 
 
 def main() -> None:
@@ -45,7 +58,8 @@ def main() -> None:
     if not data:
         print("No analytics data fetched")
         return
-    write_summary(data)
+    if not write_summary(data):
+        sys.exit(1)
     print(f"Appended analytics summary to {SUMMARY_FILE}")
 
 

--- a/catdata-pipeline/cms_publish/cms_publish.py
+++ b/catdata-pipeline/cms_publish/cms_publish.py
@@ -44,7 +44,12 @@ def main() -> None:
     success = True
     for md_file in CONTENT_DIR.glob("*.md"):
         title = md_file.stem.replace("_", " ").title()
-        body = md_file.read_text()
+        try:
+            body = md_file.read_text()
+        except Exception as e:
+            logging.error("Failed to read %s: %s", md_file, e)
+            success = False
+            continue
         if not publish_page(title, body):
             success = False
     if not success:

--- a/catdata-pipeline/content_gen/content_gen.py
+++ b/catdata-pipeline/content_gen/content_gen.py
@@ -7,6 +7,7 @@ import os
 from pathlib import Path
 from typing import Dict
 import logging
+import sys
 
 import openai
 
@@ -14,7 +15,11 @@ DISCLOSURE_LINE = "As an Amazon Associate I earn from qualifying purchases."
 
 DATA_DIR = Path(__file__).resolve().parents[1] / "data"
 CONTENT_DIR = Path(__file__).resolve().parents[1] / "content"
-CONTENT_DIR.mkdir(exist_ok=True)
+try:
+    CONTENT_DIR.mkdir(exist_ok=True)
+except Exception as e:
+    logging.error("Failed to create content directory: %s", e)
+    sys.exit(1)
 RATINGS_FILE = DATA_DIR / "ratings.json"
 
 logging.basicConfig(
@@ -47,12 +52,20 @@ def generate_article(topic: str, rating_data: Dict) -> str:
 
 
 def main() -> None:
-    data = json.loads(RATINGS_FILE.read_text())["ratings"]
+    try:
+        data = json.loads(RATINGS_FILE.read_text())["ratings"]
+    except Exception as e:
+        logging.error("Failed to read ratings file: %s", e)
+        sys.exit(1)
     for topic, entries in data.items():
         content = generate_article(topic, entries)
         md_path = CONTENT_DIR / f"{topic}.md"
-        md_path.write_text(content)
-        print(f"Wrote {md_path}")
+        try:
+            md_path.write_text(content)
+            print(f"Wrote {md_path}")
+        except Exception as e:
+            logging.error("Failed to write %s: %s", md_path, e)
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/catdata-pipeline/data_ingest/data_ingest.py
+++ b/catdata-pipeline/data_ingest/data_ingest.py
@@ -18,7 +18,11 @@ import logging
 import requests
 
 DATA_DIR = Path(__file__).resolve().parents[1] / "data"
-DATA_DIR.mkdir(exist_ok=True)
+try:
+    DATA_DIR.mkdir(exist_ok=True)
+except Exception as e:
+    logging.error("Failed to create data directory: %s", e)
+    sys.exit(1)
 RAW_RATINGS_FILE = DATA_DIR / "ratings_raw.json"
 
 logging.basicConfig(level=logging.ERROR, format="%(asctime)s %(levelname)s %(message)s")

--- a/catdata-pipeline/rating/rating.py
+++ b/catdata-pipeline/rating/rating.py
@@ -6,10 +6,14 @@ import json
 from pathlib import Path
 from typing import List, Dict
 import math
+import logging
+import sys
 
 DATA_DIR = Path(__file__).resolve().parents[1] / "data"
 RAW_RATINGS_FILE = DATA_DIR / "ratings_raw.json"
 RATINGS_FILE = DATA_DIR / "ratings.json"
+
+logging.basicConfig(level=logging.ERROR, format="%(asctime)s %(levelname)s %(message)s")
 
 WEIGHTS = {
     "durability": 0.3,
@@ -56,12 +60,21 @@ def process_ratings(raw_data: Dict[str, List[Dict[str, float]]]) -> Dict[str, Li
 
 def main() -> None:
     """Read RAW_RATINGS_FILE and write RATINGS_FILE with lives_rating."""
-    data = json.loads(RAW_RATINGS_FILE.read_text())
+    try:
+        data = json.loads(RAW_RATINGS_FILE.read_text())
+    except Exception as e:
+        logging.error("Failed to read raw ratings file: %s", e)
+        sys.exit(1)
+
     processed = process_ratings(data["ratings"])
-    RATINGS_FILE.write_text(
-        json.dumps({"generated": data.get("generated"), "ratings": processed}, indent=2)
-    )
-    print(f"Wrote processed ratings to {RATINGS_FILE}")
+    try:
+        RATINGS_FILE.write_text(
+            json.dumps({"generated": data.get("generated"), "ratings": processed}, indent=2)
+        )
+        print(f"Wrote processed ratings to {RATINGS_FILE}")
+    except Exception as e:
+        logging.error("Failed to write ratings file: %s", e)
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- wrap file/HTTP/OpenAI calls in try/except
- log failures to stderr
- exit on unrecoverable errors

## Testing
- `pytest catdata-pipeline/rating/tests catdata-pipeline/content_gen/tests catdata-pipeline/cms_publish/tests`

------
https://chatgpt.com/codex/tasks/task_e_68632df1a108832f9184e8926af0ced2