### PR TITLE
Update data ingestion to handle sheet csv

### DIFF
--- a/catdata-pipeline/data_ingest/data_ingest.py
+++ b/catdata-pipeline/data_ingest/data_ingest.py
@@ -6,6 +6,7 @@ Fetches weekly JSON rating arrays for six topics and saves them to
 
 from __future__ import annotations
 
+import csv
 import json
 import os
 import random
@@ -20,6 +21,8 @@ import requests
 DATA_DIR = Path(__file__).resolve().parents[1] / "data"
 DATA_DIR.mkdir(exist_ok=True)
 RAW_RATINGS_FILE = DATA_DIR / "ratings_raw.json"
+SHEET_CSV_URL = os.getenv("SHEET_CSV_URL", "")
+AFFILIATE_CSV = Path(__file__).resolve().parents[1] / "affiliates.csv"
 
 logging.basicConfig(level=logging.ERROR, format="%(asctime)s %(levelname)s %(message)s")
 
@@ -33,6 +36,29 @@ TOPICS = [
 ]
 
 API_TEMPLATE = os.getenv("RATINGS_API_TEMPLATE", "https://example.com/api/{topic}")
+
+
+def fetch_sheet_csv() -> List[Dict[str, str]]:
+    """Fetch affiliate sheet CSV with fallback to the local file."""
+    if not SHEET_CSV_URL:
+        logging.error("SHEET_CSV_URL not set, using local CSV")
+        csv_text = AFFILIATE_CSV.read_text()
+    else:
+        try:
+            response = requests.get(SHEET_CSV_URL, timeout=10)
+            response.raise_for_status()
+            csv_text = response.text
+        except Exception as e:
+            logging.error("Failed to fetch sheet CSV: %s", e)
+            csv_text = AFFILIATE_CSV.read_text()
+
+    reader = csv.DictReader(csv_text.splitlines())
+    return list(reader)
+
+
+def parse_products(rows: List[Dict[str, str]]) -> Dict[str, Dict[str, str]]:
+    """Convert CSV rows to product dictionaries keyed by product name."""
+    return {row.get("product_name", ""): row for row in rows}
 
 
 def fetch_topic_ratings(topic: str) -> List[Dict[str, float]]:
@@ -67,10 +93,19 @@ def main() -> None:
     all_ratings = {}
     for topic in TOPICS:
         all_ratings[topic] = fetch_topic_ratings(topic)
+
+    # Retrieve affiliate products from the sheet CSV with fallback.
+    sheet_rows = fetch_sheet_csv()
+    products = parse_products(sheet_rows)
+
     try:
         RAW_RATINGS_FILE.write_text(
             json.dumps(
-                {"generated": datetime.utcnow().isoformat(), "ratings": all_ratings},
+                {
+                    "generated": datetime.utcnow().isoformat(),
+                    "ratings": all_ratings,
+                    "products": products,
+                },
                 indent=2,
             )
         )


### PR DESCRIPTION
## Summary
- enable ingestion of product sheet CSV with fallback to affiliates.csv
- parse fetched rows into product dictionaries and store in ratings data

## Testing
- `flake8 catdata-pipeline`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68632df6b24c832f818f7753edce54ba