### PR TITLE
Improve rating engine default handling

### DIFF
--- a/catdata-pipeline/rating/rating.py
+++ b/catdata-pipeline/rating/rating.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import List, Dict
 import logging
 import math
-import logging
 import sys
 
 DATA_DIR = Path(__file__).resolve().parents[1] / "data"
@@ -29,26 +28,25 @@ logger = logging.getLogger(__name__)
 def compute_lives_rating(entry: Dict[str, float]) -> float:
     """Compute weighted lives rating on a scale of 1-9.
 
-    Values that are missing or non-numeric are treated as ``0``. The
-    returned rating is always within the range ``1``-``9`` and never ``NaN``.
+    Any missing or non-numeric sub-score defaults to ``0``.  The returned
+    value is always a finite ``float`` within the range ``1.0``-``9.0``.
     """
     score = 0.0
     for key, weight in WEIGHTS.items():
         if key not in entry:
             logger.warning("Missing key '%s' when computing rating", key)
-        value = entry.get(key, 0.0)
+        raw_value = entry.get(key, 0)
         try:
-            value = float(value)
+            numeric = float(raw_value)
+            if math.isnan(numeric) or math.isinf(numeric):
+                raise ValueError()
         except (TypeError, ValueError):
-            value = 0.0
-        if math.isnan(value) or math.isinf(value):
-            value = 0.0
-        score += value * weight
+            numeric = 0.0
+        score += numeric * weight
 
-    rating = float(score) / 5 * 8 + 1
-    if math.isnan(rating) or math.isinf(rating):
-        rating = 1.0
-    return float(max(1.0, min(9.0, rating)))
+    rating = score / 5 * 8 + 1
+    rating = float(max(1.0, min(9.0, rating)))
+    return rating
 
 
 def process_ratings(raw_data: Dict[str, List[Dict[str, float]]]) -> Dict[str, List[Dict[str, float]]]:


### PR DESCRIPTION
## Summary
- improve compute_lives_rating's default handling for missing or invalid sub-scores
- add edge case tests for rating engine

## Testing
- `pytest catdata-pipeline/rating/tests/test_rating.py catdata-pipeline/rating/tests/test_rating_edge_cases.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6863313799ac832f86e3751cc29b38a7