### PR TITLE
Implement content drafts

### DIFF
--- a/catdata-pipeline/content_gen/content_gen.py
+++ b/catdata-pipeline/content_gen/content_gen.py
@@ -1,15 +1,16 @@
-"""Content generation using OpenAI API."""
+"""Content generation using OpenAI ChatCompletion."""
 
 from __future__ import annotations
 
 import json
-import os
-from pathlib import Path
-from typing import Dict
 import logging
+import os
 import sys
+from pathlib import Path
+from typing import Dict, List
 
 import openai
+
 
 DISCLOSURE_LINE = "As an Amazon Associate I earn from qualifying purchases."
 
@@ -19,41 +20,39 @@ def add_disclosure(text: str) -> str:
     lines = [DISCLOSURE_LINE, "", text.strip(), "", DISCLOSURE_LINE]
     return "\n".join(lines)
 
+
 DATA_DIR = Path(__file__).resolve().parents[1] / "data"
 CONTENT_DIR = Path(__file__).resolve().parents[1] / "content"
-try:
-    CONTENT_DIR.mkdir(exist_ok=True)
-except Exception as e:
-    logging.error("Failed to create content directory: %s", e)
-    sys.exit(1)
 RATINGS_FILE = DATA_DIR / "ratings.json"
 
-DISCLOSURE_LINE = (
-    "FTC disclosure: This article contains affiliate links and we may earn"
-    " a commission on qualifying purchases."
-)
 
-logging.basicConfig(
-    level=logging.ERROR, format="%(asctime)s %(levelname)s %(message)s"
-)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 
-ARTICLE_PROMPT_TEMPLATE = (
-    "Write a 500 word article about {topic} for cat owners. Use rating data: {data}."
-)
+
+try:
+    CONTENT_DIR.mkdir(exist_ok=True)
+except Exception as e:  # pragma: no cover - filesystem failure
+    logging.error("Failed to create content directory: %s", e)
+    sys.exit(1)
+
 
 openai.api_key = os.getenv("OPENAI_API_KEY", "")
 
-# FTC disclosure automatically inserted at the beginning of every article
-DISCLOSURE_LINE = (
-    "FTC Disclosure: This post contains affiliate links. "
-    "If you make a purchase, we may earn a commission."
+
+TOP_X_PROMPT_TEMPLATE = (
+    "Write a markdown article titled 'Top {count} {topic}' for cat owners. "
+    "Use the following rating data to rank the products:\n{data}\n"
+    "Only return markdown."
 )
 
 
-def generate_article(topic: str, rating_data: Dict) -> str:
-    """Generate article content via OpenAI ChatCompletion."""
-    prompt = ARTICLE_PROMPT_TEMPLATE.format(
-        topic=topic, data=json.dumps(rating_data)
+def generate_article(topic: str, rating_data: List[Dict]) -> str:
+    """Generate an article via the OpenAI API."""
+    count = len(rating_data)
+    prompt = TOP_X_PROMPT_TEMPLATE.format(
+        topic=topic,
+        count=count,
+        data=json.dumps(rating_data),
     )
     try:
         resp = openai.ChatCompletion.create(
@@ -61,31 +60,35 @@ def generate_article(topic: str, rating_data: Dict) -> str:
             messages=[{"role": "user", "content": prompt}],
         )
         content = resp.choices[0].message["content"]
-        return f"{DISCLOSURE_LINE}\n\n{content}"
-    except Exception as e:
+    except Exception as e:  # pragma: no cover - network failure
         logging.error("Error generating article for %s: %s", topic, e)
-        return f"Error generating article for {topic}: {e}"
+        raise
 
-    content = resp.choices[0].message["content"]
     return add_disclosure(content)
 
 
 def main() -> None:
     try:
-        data = json.loads(RATINGS_FILE.read_text())["ratings"]
+        ratings = json.loads(RATINGS_FILE.read_text())["ratings"]
     except Exception as e:
-        logging.error("Failed to read ratings file: %s", e)
+        logging.error("Failed to read ratings file %s: %s", RATINGS_FILE, e)
         sys.exit(1)
-    for topic, entries in data.items():
-        content = generate_article(topic, entries)
+
+    for topic, entries in ratings.items():
+        logging.info("Generating article for %s", topic)
+        try:
+            article_md = generate_article(topic, entries)
+        except Exception:
+            continue
+
         md_path = CONTENT_DIR / f"{topic}.md"
         try:
-            md_path.write_text(content)
+            md_path.write_text(article_md)
             print(f"Wrote {md_path}")
-        except Exception as e:
+        except Exception as e:  # pragma: no cover - filesystem failure
             logging.error("Failed to write %s: %s", md_path, e)
-            sys.exit(1)
 
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- rewrite content generator to use ratings.json and OpenAI ChatCompletion API
- ensure affiliate disclosure lines are wrapped around the generated content
- rebuild cms_publish with matching disclosure behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863319744e8832fb857be0e64031936