### PR TITLE
Fix compute_lives_rating defaults and range

### DIFF
--- a/catdata-pipeline/rating/rating.py
+++ b/catdata-pipeline/rating/rating.py
@@ -28,12 +28,17 @@ logger = logging.getLogger(__name__)
 def compute_lives_rating(entry: Dict[str, float]) -> float:
     """Compute weighted lives rating on a scale of 1-9.
 
+    Each expected sub-score (``durability``, ``safety``, ``value`` and
+    ``convenience``) contributes to the final rating according to ``WEIGHTS``.
+    Missing or non-numeric values are treated as ``0``.  Missing keys trigger a
+    ``logger.warning`` message.  The result is clamped to the inclusive range
+    ``1.0`` to ``9.0``.
     """
 
     score = 0.0
     for key, weight in WEIGHTS.items():
-        value = entry.get(key)
-        if value is None:
+        raw_value = entry.get(key)
+        if raw_value is None:
             logger.warning("Missing key '%s' when computing rating", key)
 
         try:
@@ -41,8 +46,13 @@ def compute_lives_rating(entry: Dict[str, float]) -> float:
             if math.isnan(numeric) or math.isinf(numeric):
                 raise ValueError()
         except (TypeError, ValueError):
+            numeric = 0.0
 
-    return rating
+        score += numeric * weight
+
+    rating = (score / 5.0) * 8.0 + 1.0
+    rating = max(1.0, min(9.0, rating))
+    return float(rating)
 
 
 def process_ratings(raw_data: Dict[str, List[Dict[str, float]]]) -> Dict[str, List[Dict[str, float]]]:


### PR DESCRIPTION
## Summary
- handle missing and non-numeric subscores in `compute_lives_rating`
- clamp rating to the 1.0-9.0 range
- issue warnings when expected keys are missing
- add edge case tests for the rating engine

## Testing
- `pytest catdata-pipeline/rating/tests -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68633412b1d4832fb35f748b01c76d18