### PR TITLE
Enhance CMS publish with images

### DIFF
--- a/catdata-pipeline/cms_publish/cms_publish.py
+++ b/catdata-pipeline/cms_publish/cms_publish.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import csv
 import logging
 import os
 import sys
@@ -12,6 +13,7 @@ import requests
 
 
 CONTENT_DIR = Path(__file__).resolve().parents[1] / "content"
+AFFILIATE_CSV = Path(__file__).resolve().parents[1] / "affiliates.csv"
 CMS_API_URL = os.getenv("CMS_API_URL", "https://cms.example.com/api/pages")
 CMS_API_KEY = os.getenv("CMS_API_KEY", "")
 
@@ -20,16 +22,30 @@ DISCLOSURE_LINE = "As an Amazon Associate I earn from qualifying purchases."
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 
 
-def publish_page(title: str, body: str) -> bool:
+def load_rows() -> list[dict]:
+    """Load affiliate rows from CSV."""
+    try:
+        with AFFILIATE_CSV.open() as f:
+            reader = csv.DictReader(f)
+            return list(reader)
+    except Exception as exc:  # pragma: no cover - filesystem failure
+        logging.error("Failed to read %s: %s", AFFILIATE_CSV, exc)
+        return []
+
+
+def publish_page(title: str, body: str, image_url: str | None = None) -> bool:
     """Create or update a page via Lovable CMS API."""
-    if DISCLOSURE_LINE not in body:
+    if not body.lstrip().startswith(DISCLOSURE_LINE):
         body = f"{DISCLOSURE_LINE}\n\n{body}"
+
     payload = {
         "title": title,
         "body": body,
         "meta_description": f"Article about {title}",
         "publish_date": datetime.utcnow().isoformat(),
     }
+    if image_url:
+        payload["featured_image"] = image_url
     headers = {"Authorization": f"Bearer {CMS_API_KEY}"}
     try:
         resp = requests.post(CMS_API_URL, json=payload, headers=headers, timeout=10)
@@ -43,10 +59,17 @@ def publish_page(title: str, body: str) -> bool:
 
 def main() -> None:
     success = True
-    for md_file in CONTENT_DIR.glob("*.md"):
-        title = md_file.stem
+    rows = load_rows()
+    for row in rows:
+        title = row.get("product_name", "").strip() or "Untitled"
+        image_url = row.get("image_url", "")
+        md_file = CONTENT_DIR / f"{title}.md"
+        if not md_file.exists():
+            logging.error("Missing content for %s", title)
+            success = False
+            continue
         body = md_file.read_text()
-        if not publish_page(title, body):
+        if not publish_page(title, body, image_url):
             success = False
 
     if not success:

--- a/catdata-pipeline/cms_publish/tests/test_cms_publish.py
+++ b/catdata-pipeline/cms_publish/tests/test_cms_publish.py
@@ -15,15 +15,16 @@ class FakeResponse:
 @patch("requests.post", return_value=FakeResponse())
 def test_publish_page_injects_disclosure(mock_post):
     body = "Some article"
-    cms_publish.publish_page("Title", body)
-    sent = mock_post.call_args[1]["json"]["body"]
-    assert sent.startswith(cms_publish.DISCLOSURE_LINE)
+    cms_publish.publish_page("Title", body, image_url="img")
+    sent_payload = mock_post.call_args[1]["json"]
+    assert sent_payload["body"].startswith(cms_publish.DISCLOSURE_LINE)
+    assert sent_payload["featured_image"] == "img"
 
 
 @patch("requests.post", return_value=FakeResponse())
 def test_publish_page_preserves_disclosure(mock_post):
     body = f"{cms_publish.DISCLOSURE_LINE}\n\nContent"
-    cms_publish.publish_page("Title", body)
+    cms_publish.publish_page("Title", body, image_url="img")
     sent = mock_post.call_args[1]["json"]["body"]
     assert sent.startswith(cms_publish.DISCLOSURE_LINE)
     assert sent.count(cms_publish.DISCLOSURE_LINE) == 1

--- a/catdata-pipeline/rating/rating.py
+++ b/catdata-pipeline/rating/rating.py
@@ -26,22 +26,24 @@ logger = logging.getLogger(__name__)
 
 
 def compute_lives_rating(entry: Dict[str, float]) -> float:
-    """Compute weighted lives rating on a scale of 1-9.
-
-    """
+    """Compute weighted lives rating on a scale of 1-9."""
 
     score = 0.0
     for key, weight in WEIGHTS.items():
         value = entry.get(key)
         if value is None:
             logger.warning("Missing key '%s' when computing rating", key)
-
+            value = 0
         try:
-            numeric = float(raw_value)
+            numeric = float(value)
             if math.isnan(numeric) or math.isinf(numeric):
                 raise ValueError()
         except (TypeError, ValueError):
+            numeric = 0.0
+        score += numeric * weight
 
+    rating = (score / 5) * 8 + 1
+    rating = max(1.0, min(9.0, rating))
     return rating
 
 


### PR DESCRIPTION
## Summary
- add ability to read affiliate CSV rows
- include featured image when publishing pages
- ensure disclosure line is injected only when missing
- adjust tests
- fix rating helper functions so tests run

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863341ccf84832fbc5d2ca0d68d966d